### PR TITLE
Organise dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-pg = ["sqlalchemy[postgresql-psycopg]"]
-dev = ["werkzeug"]
-mypy = ["mypy"]
+pg = [
+  "sqlalchemy[postgresql-psycopg]"
+]
 
 [build-system]
 requires = ["setuptools"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,25 @@
-psycopg[binary]
-pydantic
-python-socketio
-sqlalchemy
-werkzeug
-gunicorn
-mypy
+# Runtime
+annotated-types==0.7.0
+bidict==0.23.1
+greenlet==3.2.4
+gunicorn==23.0.0
+h11==0.16.0
+packaging==25.0
+pydantic==2.11.9
+pydantic_core==2.33.2
+python-engineio==4.12.3
+python-socketio==5.14.0
+simple-websocket==1.1.0
+SQLAlchemy==2.0.43
+typing_extensions==4.15.0
+typing-inspection==0.4.2
+wsproto==1.2.0
+
+# Development
+build==1.3.0
+MarkupSafe==3.0.3
+pyproject_hooks==1.2.0
+Werkzeug==3.1.3
+
+# Postgres
+psycopg==3.2.10


### PR DESCRIPTION
I guess the only thing to note is that the end user (me) is now free to choose to install `psycopg-c` instead of `psycopg-binary` after running `pip install -r requirements.txt`