### PR TITLE
Use flipped tile in closed kan on win screen

### DIFF
--- a/client/src/components/game/tile_2d/tile_2d.css
+++ b/client/src/components/game/tile_2d/tile_2d.css
@@ -1,9 +1,7 @@
-.tile_2d {
+.tile_2d.tile_div {
   --tile-border-radius: calc(var(--tile-width) * 0.1);
   --tile-side-darken-percent: 8%;
-}
 
-.tile_2d.tile_div {
   --tile-height: calc(var(--tile-width) * 4 / 3);
   --tile-depth: calc(var(--tile-width) * 2 / 3);
   --tile-border-width: 1px;
@@ -11,51 +9,80 @@
   height: calc(var(--tile-height) * 9 / 8);
   display: inline-block;
   position: relative;
-}
 
-.tile_2d.tile_div .tile_back_layer,
-.tile_2d.tile_div .tile_middle_layer {
-  width: var(--tile-width);
-  height: var(--tile-height);
-  position: absolute;
-  border-radius: var(--tile-border-radius);
-}
+  .tile_back_layer,
+  .tile_middle_layer {
+    width: var(--tile-width);
+    height: var(--tile-height);
+    position: absolute;
+    border-radius: var(--tile-border-radius);
+  }
 
-.tile_2d.tile_div .tile_back_layer {
-  bottom: calc(var(--tile-height) * 1 / 8);
-  background-color: color-mix(
-    in srgb,
-    var(--tile-back-color),
-    black var(--tile-side-darken-percent)
-  );
-}
+  .tile_front_layer,
+  .tile_image {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    border-radius: var(--tile-border-radius);
+  }
 
-.tile_2d.tile_div .tile_middle_layer {
-  bottom: calc(var(--tile-height) * 1 / 8 * 0.7);
-  background-color: color-mix(
-    in srgb,
-    var(--tile-front-color),
-    black var(--tile-side-darken-percent)
-  );
-}
+  &::after {
+    --border-width: 1px;
+    content: "";
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    border-radius: var(--tile-border-radius);
+    border: var(--border-width) solid var(--tile-border-color);
+  }
 
-.tile_2d.tile_div .tile_image {
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  border: var(--tile-border-width) solid var(--tile-border-color);
-  border-radius: var(--tile-border-radius);
-  border-color: var(--tile-front-color);
-}
+  &.tile_2d_front {
+    .tile_back_layer {
+      bottom: calc(var(--tile-height) * 1 / 8);
+      background-color: color-mix(
+        in srgb,
+        var(--tile-back-color),
+        black var(--tile-side-darken-percent)
+      );
+    }
 
-.tile_2d.tile_div::after {
-  --border-width: 1px;
-  content: "";
-  width: calc(100% - 2 * var(--border-width));
-  height: calc(100% - 2 * var(--border-width));
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  border-radius: var(--tile-border-radius);
-  border: var(--border-width) solid var(--tile-border-color);
+    .tile_middle_layer {
+      bottom: calc(var(--tile-height) * 1 / 8 * 0.7);
+      background-color: color-mix(
+        in srgb,
+        var(--tile-front-color),
+        black var(--tile-side-darken-percent)
+      );
+    }
+  }
+
+  &.tile_2d_back {
+    .tile_back_layer {
+      bottom: calc(var(--tile-height) * 1 / 8);
+      background-color: color-mix(
+        in srgb,
+        var(--tile-front-color),
+        black var(--tile-side-darken-percent)
+      );
+    }
+
+    .tile_middle_layer {
+      bottom: calc(var(--tile-height) * 1 / 8 * 0.3);
+      background-color: color-mix(
+        in srgb,
+        var(--tile-back-color),
+        black var(--tile-side-darken-percent)
+      );
+    }
+
+    .tile_front_layer {
+      box-sizing: border-box;
+      width: var(--tile-width);
+      height: var(--tile-height);
+      background-color: var(--tile-back-color);
+    }
+  }
 }

--- a/client/src/components/game/tile_2d/tile_2d.tsx
+++ b/client/src/components/game/tile_2d/tile_2d.tsx
@@ -6,10 +6,20 @@ import "./tile_2d.css";
 
 export function Tile2D({ tile }: { tile: TileId }) {
   return (
-    <span class="tile_div tile_2d">
+    <span class="tile_div tile_2d tile_2d_front">
       <div class="tile_back_layer" />
       <div class="tile_middle_layer" />
       <TileImage tile={tile} />
+    </span>
+  );
+}
+
+export function Tile2DBack() {
+  return (
+    <span class="tile_div tile_2d tile_2d_back">
+      <div class="tile_back_layer" />
+      <div class="tile_middle_layer" />
+      <div class="tile_front_layer" />
     </span>
   );
 }

--- a/client/src/components/game/tile_image/tile_image.css
+++ b/client/src/components/game/tile_image/tile_image.css
@@ -5,7 +5,7 @@
 }
 
 .tile_image {
-  --tile-padding: calc(var(--tile-width) * 0.02);
+  --tile-padding: calc(var(--tile-width) * 0.04);
   box-sizing: border-box;
   width: var(--tile-width);
   height: var(--tile-height);

--- a/client/src/components/game/win_hand/win_hand.tsx
+++ b/client/src/components/game/win_hand/win_hand.tsx
@@ -1,11 +1,21 @@
-import { getCallTiles, type Call } from "../../../types/call";
+import { CallType, getCallTiles, type Call } from "../../../types/call";
 import type { Win } from "../../../types/game";
 
-import { Tile2DList } from "../tile_2d/tile_2d";
+import { Tile2D, Tile2DBack, Tile2DList } from "../tile_2d/tile_2d";
 
 import "./win_hand.css";
 
 function WinCall({ call }: { call: Call }) {
+  if (call.call_type == CallType.CLOSED_KAN) {
+    return (
+      <span class="call">
+        <Tile2DBack />
+        <Tile2D tile={call.tiles[1]} />
+        <Tile2D tile={call.tiles[2]} />
+        <Tile2DBack />
+      </span>
+    );
+  }
   return (
     <span class="call">
       <Tile2DList tiles={getCallTiles(call)} />


### PR DESCRIPTION
Fixes #21.

Screenshot for reference:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/21311f2b-7c18-4bb6-8722-614de04f1eb9" />
