### PR TITLE
add option to set fixed fu value for Seven Pairs

### DIFF
--- a/client/src/components/game/options_form/input_props.ts
+++ b/client/src/components/game/options_form/input_props.ts
@@ -291,6 +291,20 @@ export const inputPropsList: OptionsInputProps<GameOptions>[] = [
         type: "checkbox",
       },
       {
+        name: "seven_pairs_use_fixed_fu",
+        labelText: "Use fixed fu value for Seven Pairs",
+        description: `Use a fixed fu value for hands that win with the
+          Seven Pairs pattern.`,
+        type: "checkbox",
+      },
+      {
+        name: "seven_pairs_fixed_fu",
+        labelText: "Fu value for Seven Pairs",
+        description: `The fixed fu value for hands with the Seven Pairs pattern,
+          if the "Use fixed fu value for Seven Pairs" option is enabled.`,
+        type: "number",
+      },
+      {
         name: "round_up_points",
         labelText: "Round up points",
         description: `Round up a winning player's point gain from each player to

--- a/client/src/types/game_options.ts
+++ b/client/src/types/game_options.ts
@@ -32,6 +32,8 @@ export type GameOptions = {
   calculate_fu: boolean;
   base_fu: number;
   round_up_fu: boolean;
+  seven_pairs_use_fixed_fu: boolean;
+  seven_pairs_fixed_fu: number;
   round_up_points: boolean;
 
   base_score_limits: ScoreLimit[];

--- a/client/src/types/game_options_presets.ts
+++ b/client/src/types/game_options_presets.ts
@@ -402,6 +402,8 @@ const default_preset = {
   start_score: 0,
   calculate_fu: false,
   base_fu: 25,
+  seven_pairs_use_fixed_fu: true,
+  seven_pairs_fixed_fu: 25,
   round_up_fu: false,
   round_up_points: false,
   base_score_limits: [{ han: 6, score: 6400 }],
@@ -829,6 +831,8 @@ const riichi_preset = {
   calculate_fu: true,
   base_fu: 20,
   round_up_fu: true,
+  seven_pairs_use_fixed_fu: true,
+  seven_pairs_fixed_fu: 25,
   round_up_points: true,
   show_shanten_info: false,
   base_score_limits: [

--- a/src/zundamahjong/mahjong/game_options.py
+++ b/src/zundamahjong/mahjong/game_options.py
@@ -112,6 +112,15 @@ class GameOptions(BaseModel):
     """
     Whether to round up the total fu to the next multiple of 10.
     """
+    seven_pairs_use_fixed_fu: bool = True
+    """
+    Whether a seven-pairs hand should score a fixed amount of fu.
+    """
+    seven_pairs_fixed_fu: int = 25
+    """
+    The amount of fu a seven-pairs hand will score, if the option to score
+    a fixed amount of fu for a seven-pairs hand is enabled.
+    """
     round_up_points: bool = False
     """
     Whether to round up the total points each losing player plays to the next

--- a/src/zundamahjong/mahjong/scoring.py
+++ b/src/zundamahjong/mahjong/scoring.py
@@ -145,10 +145,15 @@ class Scorer:
             fu = self._options.base_fu + sum(
                 pattern_data.fu for (_, pattern_data) in patterns
             )
+            if self._options.round_up_fu:
+                fu = _round_up_int(fu, 10)
+            if (
+                "SEVEN_PAIRS" in pattern_mults
+                and self._options.seven_pairs_use_fixed_fu
+            ):
+                fu = self._options.seven_pairs_fixed_fu
         else:
             fu = self._options.base_fu
-        if self._options.round_up_fu:
-            fu = _round_up_int(fu, 10)
         player_scores = self._get_player_scores(han, fu)
         if self._options.calculate_fu:
             patterns_dict = dict(

--- a/tests/scoring_test.py
+++ b/tests/scoring_test.py
@@ -212,6 +212,36 @@ class ScoringTest(unittest.TestCase):
         self.assertEqual(scoring.fu, 28)
         self.assertSequenceEqual(scoring.player_scores, [672.0, -672.0, 0.0, 0.0])
 
+    def test_seven_pairs_fu(self) -> None:
+        win = Win(
+            win_player=0,
+            lose_player=1,
+            hand=[31, 40, 41, 90, 91, 150, 151, 210, 211, 220, 221, 310, 311, 30],
+            calls=[],
+            flowers=[420],
+            player_count=4,
+            wind_round=0,
+            sub_round=0,
+        )
+        scoring = Scorer.score(
+            win,
+            GameOptions(
+                calculate_fu=True,
+                base_fu=20,
+                round_up_fu=True,
+                seven_pairs_use_fixed_fu=True,
+            ),
+        )
+        self.assertDictEqual(
+            scoring.patterns,
+            {
+                "SEVEN_PAIRS": PatternData(display_name="Seven Pairs", han=3, fu=0),
+            },
+        )
+        self.assertEqual(scoring.han, 3)
+        self.assertEqual(scoring.fu, 25)
+        self.assertSequenceEqual(scoring.player_scores, [4800.0, -4800.0, 0.0, 0.0])
+
     def test_fu_rounding(self) -> None:
         win = Win(
             win_player=0,


### PR DESCRIPTION
Fixes #55.

This branch adds two new options: an option to make all Seven Pairs hands have a fixed fu value, and an option to set that fu value.